### PR TITLE
Blog: The Azure Service You're Probably Not Using (Durable Task Scheduler)

### DIFF
--- a/_posts/2026-04-07-durable-task-scheduler.md
+++ b/_posts/2026-04-07-durable-task-scheduler.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "This Is the Best Framework and Azure Service You're Probably Not Using"
-date: 2026-04-10
+date: 2026-04-07
 tags: [azure, durable-task-sdk, durable-task-scheduler, durable-functions, orchestration, workflows, background-jobs, dotnet]
 ---
 

--- a/_posts/2026-04-10-durable-task-scheduler.md
+++ b/_posts/2026-04-10-durable-task-scheduler.md
@@ -1,280 +1,395 @@
 ---
 layout: post
-title: "The Azure Service I Should Have Been Using For Years (But Wasn't)"
+title: "This Is the Best Framework and Azure Service You're Probably Not Using"
 date: 2026-04-10
-tags: [azure, durable-task, orchestration, dotnet, workflow, distributed-systems]
-description: "A deep dive into the Durable Task Framework and Azure Durable Task Scheduler — the underrated orchestration stack that handles all the hard stuff so you don't have to."
+tags: [azure, durable-task-framework, durable-functions, orchestration, workflows, background-jobs, dotnet]
 ---
 
-> *"The greatest trick the devil ever pulled was convincing the world he didn't exist."*  
-> — Keyser Söze, The Usual Suspects  
-> *(Also: every underrated Azure service ever.)*
+I've been circling this technology for almost a decade. Stick with me.
 
-Let me tell you about the conversation I had with myself last spring.
+Back in 2017, I was a Senior Architect at CodeValue, and I wrote one of the early deep-dives on Azure Durable Functions for [Microsoft's MVP Award blog](https://learn.microsoft.com/en-us/archive/blogs/mvpawardprogram/azure-durable-functions). Durable Functions was barely out of beta. I had a disclaimer in the post saying "not production ready." I showed code samples with `OrchestrationTrigger` and `ActivityTrigger`, explained the checkpoint-and-replay model, even [published a sample on GitHub](https://github.com/tamirdresher/azure-functions-durable-extension/blob/master/samples/precompiled/HelloSequence.cs). I thought: *this is the future of distributed workflows*.
 
-I was neck-deep in a distributed workflow problem. We had a multi-step process that needed to fan out across dozens of parallel tasks, aggregate results, handle retries on transient failures, survive process restarts, and — the kicker — wait for an external human approval that might come back in five minutes or five days.
+Then I moved to Payoneer.
 
-My first instinct was to reach for a message queue and a state table and a timer and maybe some Blob storage for checkpoints, and before I knew it I was looking at a whiteboard that looked like someone had taken a flight map and asked it to explain itself. I'd been here before. I'd solved this before. And I was about to solve it *again*, from scratch, the hard way.
+If you've never worked in fintech at scale, let me paint the picture. We were running **hundreds of thousands of concurrent payment workflows**. Multi-step flows that needed to fan out across microservices, retry on transient failures, survive process crashes, and maintain perfect idempotency because you can't accidentally charge someone twice. Reliability wasn't a feature. It was oxygen.
 
-A colleague (who had clearly been waiting for the right moment) asked: "Have you looked at Durable Task?"
+We needed a workflow engine. We evaluated options. We ended up going deep on **Netflix Conductor** — and I mean *deep*. Custom worker SDKs. Redis fsync tuning. Queue starvation debugging. We built a disaster recovery setup with site-aware workers. We hit scaling limits that forced us to stop indexing tasks because Elasticsearch couldn't keep up. My colleague Amir Popovich [wrote up the whole journey](https://engineering.payoneer.com/our-journey-making-netflix-conductor-production-ready-for-our-platform-608d2a192035), and [I shared it publicly because I was genuinely proud of what we'd built](https://www.linkedin.com/posts/tamirdresher_when-our-platform-met-conductor-activity-7145037540994043904-GAG2). (I also [talked about it on a podcast](https://open.spotify.com/episode/1WMLngV43KELbIuTH5zbQL), if you prefer Hebrew.)
 
-Reader, I had not. Not really. I knew it existed. I'd skimmed a docs page once. I had lumped it in with "things that are probably cool but require Azure Functions" and filed it under *look at later*. Later never came.
+Conductor was the right call. DSL-based, language-agnostic, proven at Netflix scale. It worked.
 
-That was a mistake. Let me save you from making the same one.
+But here's the thing that makes me laugh now: while I was tuning Redis persistence modes and writing custom event bridges and debugging why a single slow HTTP Task response would starve an entire queue — **the technology I wrote about in 2017 was quietly growing up**.
+
+The Durable Task Framework evolved from a beta curiosity into a standalone SDK. First-class support for .NET, Python, Java, JavaScript. Battle-tested at Microsoft scale. And now? Microsoft launched the **Durable Task Scheduler** as a fully managed Azure service.
+
+It solves **exactly** the problems I spent months wrestling with at Payoneer. The queue starvation? Built-in activity queues per task type. The Redis memory footprint from storing workflow definitions in every instance? Managed state. The idempotency concerns? Checkpointing model handles it. The worker SDK complexity? Just write C# that looks like regular async code.
+
+Full circle. Cosmic joke. Pick your metaphor.
+
+And here's the weirdest part: **almost nobody knows this exists.**
+
+I talk to .NET developers all the time. They know Azure Functions. They've heard of Durable Functions. But mention "Durable Task Framework" or "Durable Task Scheduler" and I get blank stares. Which is *wild*, because this is the exact same engine powering Durable Functions under the hood. It's open source. It's battle-tested at massive scale. It solves problems that every distributed system eventually faces.
+
+So let me tell you about the best framework and Azure service you're probably not using.
 
 ---
 
-## What Is the Durable Task Framework, Actually?
+## The Problem: Workflows Are Hard
 
-The [Durable Task Framework (DTFx)](https://github.com/Azure/durabletask) is an open-source .NET library that lets you write long-running, fault-tolerant workflows using ordinary async/await code. No state machines. No compensation tables. No custom checkpoint logic. You write a method, you `await` things, and the framework handles making it survive crashes, retries, and the general chaos of distributed systems.
+Let's start with a real scenario. You're building an order processing system. When a customer places an order, you need to:
 
-Here's the magic of it. Imagine you want to model this workflow:
+1. **Charge their credit card**
+2. **Reserve inventory**
+3. **Send a confirmation email**
+4. **Wait 30 minutes** (in case they cancel)
+5. **If not canceled, ship the order**
+6. **Send a shipping notification**
 
-1. Receive an order
-2. Verify payment (can fail, should retry)
-3. Fan out to notify warehouse, shipping, and analytics in parallel
-4. Wait for warehouse to confirm inventory (could take hours)
-5. Update order status
+This seems simple, right? Until you think about what happens when things go wrong:
 
-Without orchestration primitives, this is a nightmare of queues, timers, and state tracking spread across multiple services. With DTFx, it looks like this:
+- What if the email service is down?
+- What if your app crashes between step 3 and 4?
+- What if the customer cancels during the 30-minute wait?
+- What if the database connection drops after reserving inventory but before charging the card?
+
+Suddenly, you're writing retry logic, checkpointing state, handling timeouts, and building compensation workflows (rolling back inventory if payment fails). You've turned a simple business process into a distributed systems nightmare.
+
+Here's what this looks like with **Hangfire**:
 
 ```csharp
-[DurableTask]
-public class OrderFulfillmentOrchestration : TaskOrchestrator<OrderInput, OrderResult>
+// Step 1: Queue the first job
+BackgroundJob.Enqueue(() => ChargeCard(orderId));
+
+// Step 2: You need to remember to queue the next step after the first succeeds
+public void ChargeCard(int orderId)
 {
-    public override async Task<OrderResult> RunAsync(
-        TaskOrchestrationContext context, OrderInput order)
-    {
-        // Step 1: Verify payment — retries on transient failure
-        var paymentResult = await context.CallActivityAsync<PaymentResult>(
-            nameof(VerifyPaymentActivity), order,
-            new TaskOptions { Retry = new RetryPolicy(maxRetries: 3, firstRetryInterval: TimeSpan.FromSeconds(5)) });
-
-        if (!paymentResult.Success)
-            return OrderResult.PaymentFailed(paymentResult.Reason);
-
-        // Step 2: Fan out notifications in parallel
-        var tasks = new[]
-        {
-            context.CallActivityAsync(nameof(NotifyWarehouseActivity), order),
-            context.CallActivityAsync(nameof(NotifyShippingActivity), order),
-            context.CallActivityAsync(nameof(NotifyAnalyticsActivity), order),
-        };
-        await Task.WhenAll(tasks);
-
-        // Step 3: Wait for external inventory confirmation — could be hours, no polling
-        var confirmation = await context.WaitForExternalEventAsync<InventoryConfirmation>(
-            "InventoryConfirmed",
-            timeout: TimeSpan.FromHours(48));
-
-        return OrderResult.Fulfilled(confirmation.EstimatedShipDate);
-    }
-}
-```
-
-Read that again. That `WaitForExternalEventAsync` call — your process can sleep for 48 hours waiting for that event, and if the host crashes while waiting, when it comes back up the orchestration resumes exactly where it left off. No polling. No stored timer records. No "check if we have a pending approval row in the database." The framework reconstructs the orchestration's state by replaying the history.
-
-This is the bit that took me a minute to fully appreciate. The code looks synchronous and simple. Under the hood, the framework is storing every step as an event log and replaying that log to reconstruct state. It's event sourcing, but you never write the event sourcing code.
-
----
-
-## The Part I Glossed Over: DTFx vs. Durable Functions vs. Durable Task SDKs
-
-Okay, this is where the naming gets a little confusing, and I want to untangle it properly because I definitely got confused.
-
-- **DTFx (Durable Task Framework)** — the original, community-maintained open-source library. Think of it as the core engine. Powerful, battle-tested (Microsoft's own teams use it in production), but community-supported rather than Microsoft-supported.
-
-- **Durable Functions** — Azure Functions' hosted orchestration experience. Built on DTFx under the hood. If you're already in the Functions world, this is the natural path. Full Microsoft support, tight Functions integration.
-
-- **Durable Task SDKs** — the modern, officially-supported, polyglot evolution. Available for .NET, Python, Java, and JavaScript/TypeScript. These work on *any compute* — Azure Container Apps, AKS, VMs, your laptop. Not tied to Azure Functions at all.
-
-- **Azure Durable Task Scheduler** — the managed Azure backend for the Durable Task SDKs and Durable Functions. Think of it as "we run the hard orchestration infrastructure, you just run your app."
-
-For a new project? Start with the **Durable Task SDKs + Azure Durable Task Scheduler**. You get official Microsoft support, a built-in dashboard, multi-language support, and you're not locked to Functions hosting. That's the stack I'll focus on for the rest of this post.
-
----
-
-## Why the Scheduler Changes Things
-
-When I say "managed backend," I don't want that to sound boring. Here's what it actually means.
-
-In the old DIY world of running DTFx yourself, you had to provision storage (Service Bus queues, Azure Storage accounts, or a SQL database), manage connection strings, deal with partition management overhead consuming your app's CPU, and figure out how to observe what's actually happening in your orchestrations.
-
-The **Azure Durable Task Scheduler** is a purpose-built Azure resource (`Microsoft.DurableTask/schedulers`) that takes all of that away:
-
-**No polling.** Work items are pushed to your app over a gRPC connection. Your app isn't burning cycles asking "anything for me?" — the scheduler pushes work the moment it's ready.
-
-**No storage account to manage.** State lives inside the scheduler resource. Highly optimized for this exact use case. Lower latency, better durability, less operational noise.
-
-**A dashboard that actually ships with the product.** Not "here's how to hook up Azure Monitor and build some queries." An actual UI, out of the box, where you can see all your orchestration instances, drill into their history, see what steps ran, how long each activity took, and perform management operations like pausing or terminating a stuck workflow.
-
-**Task hubs for isolation.** One scheduler resource, multiple task hubs — one per environment, one per team, whatever makes sense. They share the scheduler's resources but stay logically isolated.
-
-And for local development: a **Docker emulator** that runs the full scheduler locally. No Azure subscription needed to iterate.
-
-```bash
-docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 \
-  mcr.microsoft.com/dts/dts-emulator:latest
-```
-
-That's it. Full local scheduler, with the same dashboard UI, pointing at `http://localhost:8082`.
-
----
-
-## Getting Started: A Real Code Walkthrough
-
-Let me show you a minimal but complete example using the .NET SDK. We're building a fan-out/fan-in orchestration — kick off a bunch of parallel tasks, wait for all of them, aggregate the results. Classic pattern, surprisingly painful to implement yourself.
-
-**Install the packages:**
-
-```bash
-dotnet add package Microsoft.DurableTask.Worker.AzureManaged
-dotnet add package Microsoft.DurableTask.Client.AzureManaged
-```
-
-**Define the orchestration and activities:**
-
-```csharp
-// The orchestration — runs on the worker, coordinates everything
-[DurableTask]
-public class BatchProcessingOrchestration : TaskOrchestrator<string[], BatchResult>
-{
-    public override async Task<BatchResult> RunAsync(
-        TaskOrchestrationContext context, string[] items)
-    {
-        context.SetCustomStatus("Processing started");
-
-        // Fan out: kick off one activity per item, all in parallel
-        var tasks = items.Select(item =>
-            context.CallActivityAsync<ItemResult>(
-                nameof(ProcessItemActivity), item));
-
-        var results = await Task.WhenAll(tasks);
-
-        // Fan in: aggregate
-        return new BatchResult
-        {
-            ProcessedCount = results.Length,
-            SuccessCount = results.Count(r => r.Success),
-            TotalDuration = results.Sum(r => r.ProcessingMs)
-        };
-    }
-}
-
-// An activity — the unit of work, runs independently
-[DurableTask]
-public class ProcessItemActivity : TaskActivity<string, ItemResult>
-{
-    public override async Task<ItemResult> RunAsync(
-        TaskActivityContext context, string item)
-    {
-        // Your actual work here — call an API, process a record, whatever
-        await Task.Delay(Random.Shared.Next(100, 500)); // simulate real work
-        return new ItemResult { Item = item, Success = true, ProcessingMs = 250 };
-    }
-}
-```
-
-**Wire up the worker (Program.cs):**
-
-```csharp
-var builder = Host.CreateApplicationBuilder(args);
-
-builder.Services.AddDurableTaskWorker(workerBuilder =>
-{
-    workerBuilder.AddTasks<BatchProcessingOrchestration>();
-    workerBuilder.AddTasks<ProcessItemActivity>();
+    // Charge the card
+    PaymentService.Charge(order);
     
-    // Uses emulator by default if no env vars set — production uses Azure
-    workerBuilder.UseAzureManaged();
-});
+    // Now what? Queue the next job manually
+    BackgroundJob.Enqueue(() => ReserveInventory(orderId));
+}
 
-builder.Services.AddDurableTaskClient(clientBuilder =>
+// Step 3: Keep chaining...
+public void ReserveInventory(int orderId)
 {
-    clientBuilder.UseAzureManaged();
-});
+    InventoryService.Reserve(order);
+    
+    // Queue the next step
+    BackgroundJob.Enqueue(() => SendEmail(orderId));
+}
+
+// You get the idea. And we haven't even handled failures yet.
+```
+
+This is fine for simple jobs. But for a multi-step workflow with waits, retries, and error handling? You end up with spaghetti. Each step is a separate job. State is stored in your database. You're manually tracking where you are in the flow.
+
+---
+
+## The Solution: Write Workflows Like They're Just Code
+
+Here's the same workflow with the **Durable Task Framework**:
+
+```csharp
+[Function("OrderOrchestrator")]
+public async Task RunOrderWorkflow(
+    [OrchestrationTrigger] TaskOrchestrationContext context)
+{
+    var orderId = context.GetInput<int>();
+    
+    // Step 1: Charge the card
+    await context.CallActivityAsync("ChargeCard", orderId);
+    
+    // Step 2: Reserve inventory
+    await context.CallActivityAsync("ReserveInventory", orderId);
+    
+    // Step 3: Send confirmation email
+    await context.CallActivityAsync("SendEmail", orderId);
+    
+    // Step 4: Wait 30 minutes
+    await context.CreateTimer(context.CurrentUtcDateTime.AddMinutes(30));
+    
+    // Step 5: Check if canceled
+    var isCanceled = await context.CallActivityAsync<bool>("CheckCancellation", orderId);
+    
+    if (!isCanceled)
+    {
+        // Step 6: Ship the order
+        await context.CallActivityAsync("ShipOrder", orderId);
+        
+        // Step 7: Send shipping notification
+        await context.CallActivityAsync("SendShippingEmail", orderId);
+    }
+}
+```
+
+That's it. **That's the whole orchestration.**
+
+Notice what's missing:
+- No manual state management
+- No queue juggling
+- No "remember to queue the next step" comments
+- No distributed locking to prevent duplicate runs
+- No custom retry logic (it's built in)
+
+The orchestration is **declarative**. You write it like synchronous code, and the framework handles all the hard parts:
+
+- **Checkpointing**: After each `await`, the framework saves state. If your app crashes and restarts, it picks up exactly where it left off.
+- **Retries**: If an activity fails, the framework automatically retries it (with configurable backoff).
+- **Durability**: The orchestration can run for hours, days, or weeks. The framework doesn't care.
+- **Versioning**: You can update orchestrations while they're running. Old instances continue with the old code; new instances use the new code.
+- **External Events**: Your orchestration can wait for external signals (like a user clicking "cancel") using `WaitForExternalEvent`.
+
+---
+
+## What Makes This Different?
+
+I know what you're thinking. "Tamir, this just looks like Durable Functions with extra steps. Why would I use the Durable Task Framework directly?"
+
+Great question. Here's the thing: **Durable Functions IS built on the Durable Task Framework**. When you write a Durable Function, you're using the framework under the hood. But there are scenarios where you want the framework without the Azure Functions runtime:
+
+### Use Durable Functions When:
+- You want serverless, pay-per-execution pricing
+- You want built-in triggers (HTTP, Queue, Timer, Event Grid)
+- You want automatic scaling with zero infrastructure management
+- You're building cloud-first, Azure-native apps
+
+### Use Durable Task Framework (the SDK) When:
+- You're running on Kubernetes, VMs, or on-premises
+- You need complete control over hosting and scaling
+- You're building a hybrid or multi-cloud solution
+- You have an existing .NET app and want to add workflow orchestration without Azure Functions
+
+The framework is **open source** (https://github.com/Azure/durabletask). You can run it anywhere. You can use Azure Storage, SQL Server, or the new **Durable Task Scheduler** as the backend.
+
+---
+
+## Enter the Durable Task Scheduler: The Missing Piece
+
+Here's where it gets really good. Microsoft recently launched the **Durable Task Scheduler** as a fully managed Azure service. Think of it as the orchestration engine extracted into its own service.
+
+Before, if you wanted to run orchestrations, you had two choices:
+1. **Azure Functions** (managed, but tightly coupled to Functions runtime)
+2. **Self-hosted** (flexible, but you manage storage, scaling, monitoring)
+
+Now there's a third option: **Durable Task Scheduler**.
+
+It's a managed backend that handles:
+- State persistence (no need to configure storage accounts)
+- Automatic scaling (handles millions of orchestrations)
+- Monitoring and diagnostics (built-in dashboards)
+- Fault tolerance (orchestrations survive failures)
+
+You write code against the Durable Task SDK, point it at the Durable Task Scheduler, and you get all the benefits of a managed service without being locked into Azure Functions.
+
+Here's what that looks like:
+
+```csharp
+var builder = new HostBuilder()
+    .ConfigureTaskHubWorker((context, builder) =>
+    {
+        builder.UseDurableTaskScheduler(options =>
+        {
+            options.ResourceName = "my-task-scheduler";
+            options.ConnectionString = "..."; // From Azure Portal
+        });
+        
+        builder.AddOrchestrator<OrderOrchestrator>();
+        builder.AddActivity<ChargeCardActivity>();
+        builder.AddActivity<ReserveInventoryActivity>();
+        // ... other activities
+    });
 
 var host = builder.Build();
 await host.RunAsync();
 ```
 
-**Schedule an orchestration from the client:**
+Your orchestrations run in your container, VM, or Kubernetes cluster. The state, scheduling, and reliability? All managed by Azure. You get the best of both worlds.
+
+---
+
+## The Demo: What I'd Put in a Repo
+
+If I were to create a demo repo for this (and I might!), here's what it would contain:
+
+### 1. **Basic Orchestration Example**
+A simple "Hello, World" orchestration showing the fundamentals:
+- Orchestrator calling activities
+- Built-in retries
+- Durable timers
+
+### 2. **Fan-Out/Fan-In Pattern**
+A classic pattern where you parallelize work and wait for all results:
 
 ```csharp
-var client = host.Services.GetRequiredService<DurableTaskClient>();
-
-var items = new[] { "Item1", "Item2", "Item3", "Item4", "Item5" };
-var instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
-    nameof(BatchProcessingOrchestration), items);
-
-Console.WriteLine($"Started orchestration: {instanceId}");
-
-// Wait for it to complete
-var result = await client.WaitForInstanceCompletionAsync(instanceId);
-Console.WriteLine($"Completed: {result.SerializedOutput}");
+[Function("ProcessBatchOrchestrator")]
+public async Task ProcessBatch(
+    [OrchestrationTrigger] TaskOrchestrationContext context)
+{
+    var items = context.GetInput<List<int>>();
+    
+    // Fan-out: Process all items in parallel
+    var tasks = items.Select(item => 
+        context.CallActivityAsync<string>("ProcessItem", item)
+    );
+    
+    // Fan-in: Wait for all to complete
+    var results = await Task.WhenAll(tasks);
+    
+    return results;
+}
 ```
 
-Run the emulator first, then start the worker and client. Open `http://localhost:8082` in your browser and watch the orchestration run through the dashboard. See each activity start and complete in real time. That's not a demo rig — that's what your production setup looks like too.
+This runs all the activities in parallel (subject to concurrency limits) and waits for all of them to finish. Try doing that with Hangfire without building your own coordination logic.
+
+### 3. **Human-in-the-Loop Pattern**
+An orchestration that waits for human approval:
+
+```csharp
+[Function("ApprovalOrchestrator")]
+public async Task RunApproval(
+    [OrchestrationTrigger] TaskOrchestrationContext context)
+{
+    var request = context.GetInput<ApprovalRequest>();
+    
+    // Send approval email
+    await context.CallActivityAsync("SendApprovalEmail", request);
+    
+    // Wait for approval event (with 48-hour timeout)
+    var approvalTask = context.WaitForExternalEvent<bool>("ApprovalResponse");
+    var timeoutTask = context.CreateTimer(context.CurrentUtcDateTime.AddHours(48));
+    
+    var winner = await Task.WhenAny(approvalTask, timeoutTask);
+    
+    if (winner == approvalTask)
+    {
+        var approved = await approvalTask;
+        if (approved)
+        {
+            await context.CallActivityAsync("ProcessApprovedRequest", request);
+        }
+        else
+        {
+            await context.CallActivityAsync("RejectRequest", request);
+        }
+    }
+    else
+    {
+        // Timeout - auto-reject
+        await context.CallActivityAsync("AutoRejectRequest", request);
+    }
+}
+```
+
+The orchestration can literally wait for days for a user to click a button. The framework doesn't care. It checkpoints, sleeps, and resumes when the event arrives.
+
+### 4. **Comparison to Alternatives**
+A side-by-side comparison showing the same workflow implemented with:
+- Hangfire (manual state, queuing, retry logic)
+- Quartz.NET (cron-based, not workflow-friendly)
+- Durable Task Framework (clean, declarative)
+
+### 5. **Deployment Examples**
+How to run this on:
+- Azure Functions (serverless)
+- Azure Container Apps (containers with the Durable Task Scheduler backend)
+- Kubernetes (self-hosted with SQL or Azure Storage backend)
 
 ---
 
-## When Should You Reach for This?
+## Why Isn't Everyone Using This?
 
-Not everything needs orchestration. Simple queue-consumer patterns work fine. But if you find yourself building any of these, stop and look at Durable Task first:
+Good question. I think it's a combination of factors:
 
-**Long-running processes that need to survive restarts.** Data pipeline that takes hours. Approval workflows waiting on humans. Anything where "the host died, start over" is not acceptable.
+1. **Naming Confusion**: "Durable Functions," "Durable Task Framework," "Durable Task Scheduler" — people think they're all the same thing or don't understand the differences.
 
-**Fan-out/fan-in with real parallelism.** You need to spin up 50 parallel tasks, collect all their results, and make a decision. Doing this with a message queue and a correlation ID table works, but it's annoying to build and annoying to debug. Durable Task makes it three lines of code.
+2. **Hidden in Plain Sight**: Most developers encounter Durable Functions first and assume that's the only way to use this pattern. They don't realize the underlying framework is available independently.
 
-**Workflows with complex error handling and retries.** Built-in retry policies with exponential backoff, per-activity. Automatic state persistence means a retry doesn't re-run everything from scratch — it picks up from the last successful checkpoint.
+3. **Perceived Complexity**: The async/await orchestration model looks weird the first time you see it. "Wait, I can just `await` a 30-minute timer? That doesn't make sense!" (It does. It's brilliant.)
 
-**External event integration.** "Wait until a human approves this" or "wait until the webhook fires" or "wait up to 72 hours for a payment confirmation." Without orchestration, this is a timer + database row + polling loop. With Durable Task, it's `WaitForExternalEventAsync`.
+4. **Documentation Fragmentation**: Microsoft's docs are getting better, but there's still a lot of "if you want X, read this doc; if you want Y, read that doc; if you want Z, good luck."
 
-**Multi-agent orchestration.** This one is increasingly relevant. If you're building AI workflows where Agent A kicks off work, waits for Agent B and Agent C to finish in parallel, collects their outputs, and feeds them to Agent D — that's exactly what Durable Task is designed for. The framework already powers a lot of the infrastructure behind Semantic Kernel's process orchestration features.
-
----
-
-## The Thing I Wish Someone Had Told Me
-
-Here's my honest take after spending real time with this stack: the hardest part isn't the framework. The framework is excellent. The hardest part is accepting that you don't need to build the orchestration infrastructure yourself.
-
-I spent years writing bespoke workflow engines. Queues and state machines and compensation tables and checkpoint logic. And I'm not saying that experience was wasted — understanding what the framework is doing underneath makes you use it better. But at some point, "I could build this myself" stops being a reason to do so.
-
-The Durable Task Scheduler is a managed service that Microsoft's own engineering teams use in production. The Durable Task SDKs are officially supported, actively developed, and available in four languages. The local emulator ships a full dashboard. The pricing model has both dedicated and consumption tiers.
-
-This is a production-ready, fully-supported, genuinely well-designed piece of infrastructure. The fact that it's not in every architecture conversation is the thing I can't explain.
-
-So here's my challenge to you: next time you're about to draw a state machine on a whiteboard and figure out which queue goes where — look at Durable Task first. Spend 30 minutes with the quickstart. Run the emulator locally. Open the dashboard.
-
-I'll bet the whiteboard stays clean.
+But once you get past these hurdles, this is **the** way to build reliable workflows in .NET. It's not just for Azure. It's not just for serverless. It's a general-purpose orchestration framework that happens to have a world-class managed backend option.
 
 ---
 
-## Quick Reference
+## The Honest Reality
 
-| What you want | What to use |
-|---|---|
-| Serverless, Azure Functions hosting | Durable Functions |
-| Any compute (.NET, Python, Java, JS) | Durable Task SDKs |
-| Managed backend + dashboard | Azure Durable Task Scheduler |
-| Local development | Docker emulator (`mcr.microsoft.com/dts/dts-emulator`) |
+This isn't a silver bullet. There are scenarios where Hangfire or Quartz.NET is still the right choice:
 
-**Useful links:**
+- **Use Hangfire if**: You need simple fire-and-forget jobs with a nice dashboard, and you're okay with your database as a queue.
+- **Use Quartz.NET if**: You need complex cron scheduling, enterprise clustering, and precise timing guarantees.
+- **Use Durable Task Framework if**: You need workflows — multi-step processes with state, retries, compensation, external events, or anything that could run longer than a few minutes.
 
-- [Durable Task SDKs overview](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-overview)
-- [Azure Durable Task Scheduler docs](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler)
-- [Quickstart: Fan-out/fan-in with Durable Task SDKs](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/quickstart-portable-durable-task-sdks)
-- [Sample code repository (Azure-Samples/Durable-Task-Scheduler)](https://github.com/Azure-Samples/Durable-Task-Scheduler)
-- [Original DTFx repo (Azure/durabletask)](https://github.com/Azure/durabletask)
+But if you're building a system where you're manually stitching together background jobs into workflows, tracking state in your database, and writing custom retry logic? You're reinventing the Durable Task Framework. Stop. Use the thing that's already built and battle-tested.
 
 ---
 
-## Demo Repo
+## Getting Started
 
-> **Demo repo: [TBD — to be built]**
->
-> I'm building a companion repo that walks through a realistic end-to-end scenario: an order processing workflow with payment verification, parallel notifications, a human approval step, and full observability via the Durable Task Scheduler dashboard. Watch this space (or the GitHub issue) for the link when it's ready.
+Here's the fastest path to trying this out:
+
+### 1. **Start with Durable Functions** (easiest)
+If you're new to this, start with Durable Functions. It's the fastest way to see the orchestration model in action:
+
+```bash
+# Create a new Durable Functions app
+func init MyDurableFunctionsApp --worker-runtime dotnet-isolated
+cd MyDurableFunctionsApp
+func new --template "Durable Functions orchestration" --name OrderWorkflow
+
+# Run it locally
+func start
+```
+
+Microsoft's [Durable Functions quickstart](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-create-first-csharp) is excellent.
+
+### 2. **Try the Durable Task SDK** (for self-hosting)
+If you want to run outside Azure Functions, check out the [Durable Task SDK samples](https://github.com/Azure/durabletask):
+
+```bash
+git clone https://github.com/Azure/durabletask.git
+cd durabletask/samples
+dotnet run
+```
+
+### 3. **Explore Durable Task Scheduler** (managed backend)
+The Durable Task Scheduler is in GA for dedicated SKU and public preview for consumption SKU. Check out the [official docs](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler) for setup instructions.
 
 ---
 
-*Have you used Durable Task in production? I'd love to hear what patterns you've hit and what tripped you up. Find me on [GitHub](https://github.com/tamirdresher) or [LinkedIn](https://linkedin.com/in/tamirdresher).*
+## Where I See This Fitting
+
+Having lived through building a production Conductor deployment at Payoneer — tuning Redis persistence, debugging queue starvation, writing custom worker SDKs for hundreds of thousands of concurrent workflows — I can tell you exactly where the Durable Task Framework shines:
+
+1. **Multi-step payment processing**: The same fan-out patterns, the same retry semantics, the same survival guarantees we needed at Payoneer. Except instead of learning a DSL and maintaining separate workflow definitions, you write it as plain C# that looks like regular async code.
+
+2. **Fan-out/fan-in at scale**: What we built with custom worker SDKs and bulk processing logic becomes 50 lines of orchestration code. The coordination that required careful queue management? Built in.
+
+3. **Human-in-the-loop workflows**: Orchestrations that wait for approval with timeout escalations — a first-class pattern. The framework doesn't care if it waits five minutes or five days. No queue starvation debugging required.
+
+If I were starting that Payoneer project today with a .NET stack? I'd absolutely evaluate the Durable Task Framework with the Scheduler backend. The code-first approach maps to how .NET developers already think. And I wouldn't have to tune Redis fsync intervals at 2 AM.
+
+---
+
+## The Bottom Line
+
+If you're building distributed systems in .NET, you need to know about the Durable Task Framework and Durable Task Scheduler. It's not a niche tool. It's not just for Azure Functions. It's a fundamental pattern for reliable workflows that happens to have first-class support in Azure.
+
+Stop manually building orchestrations with job queues and database tables. Stop writing custom retry logic. Stop reinventing the wheel.
+
+Use the framework that Microsoft built, open-sourced, and uses internally at scale. It's excellent. It's underrated. And you're probably not using it.
+
+---
+
+**Want to dive deeper?** Here are the resources I wish someone had handed me earlier:
+
+- [What is Durable Task? (Official Docs)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/what-is-durable-task)
+- [Durable Task Framework GitHub](https://github.com/Azure/durabletask)
+- [Durable Task Scheduler Docs](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler)
+- [Durable Functions Patterns](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview?tabs=in-process%2Cnodejs-v3%2Cv1-model&pivots=csharp)
+
+If you're already using this and I've missed something important, or if you have your own workflow orchestration war stories (Conductor, Temporal, Hangfire, home-grown state machines — I've seen them all), I'd love to hear them. Find me on [Twitter/X](https://twitter.com/tamirdresher) or [LinkedIn](https://www.linkedin.com/in/tamirdresher).
+
+Now go build something durable. 🚀
+
+---

--- a/_posts/2026-04-10-durable-task-scheduler.md
+++ b/_posts/2026-04-10-durable-task-scheduler.md
@@ -1,0 +1,280 @@
+---
+layout: post
+title: "The Azure Service I Should Have Been Using For Years (But Wasn't)"
+date: 2026-04-10
+tags: [azure, durable-task, orchestration, dotnet, workflow, distributed-systems]
+description: "A deep dive into the Durable Task Framework and Azure Durable Task Scheduler — the underrated orchestration stack that handles all the hard stuff so you don't have to."
+---
+
+> *"The greatest trick the devil ever pulled was convincing the world he didn't exist."*  
+> — Keyser Söze, The Usual Suspects  
+> *(Also: every underrated Azure service ever.)*
+
+Let me tell you about the conversation I had with myself last spring.
+
+I was neck-deep in a distributed workflow problem. We had a multi-step process that needed to fan out across dozens of parallel tasks, aggregate results, handle retries on transient failures, survive process restarts, and — the kicker — wait for an external human approval that might come back in five minutes or five days.
+
+My first instinct was to reach for a message queue and a state table and a timer and maybe some Blob storage for checkpoints, and before I knew it I was looking at a whiteboard that looked like someone had taken a flight map and asked it to explain itself. I'd been here before. I'd solved this before. And I was about to solve it *again*, from scratch, the hard way.
+
+A colleague (who had clearly been waiting for the right moment) asked: "Have you looked at Durable Task?"
+
+Reader, I had not. Not really. I knew it existed. I'd skimmed a docs page once. I had lumped it in with "things that are probably cool but require Azure Functions" and filed it under *look at later*. Later never came.
+
+That was a mistake. Let me save you from making the same one.
+
+---
+
+## What Is the Durable Task Framework, Actually?
+
+The [Durable Task Framework (DTFx)](https://github.com/Azure/durabletask) is an open-source .NET library that lets you write long-running, fault-tolerant workflows using ordinary async/await code. No state machines. No compensation tables. No custom checkpoint logic. You write a method, you `await` things, and the framework handles making it survive crashes, retries, and the general chaos of distributed systems.
+
+Here's the magic of it. Imagine you want to model this workflow:
+
+1. Receive an order
+2. Verify payment (can fail, should retry)
+3. Fan out to notify warehouse, shipping, and analytics in parallel
+4. Wait for warehouse to confirm inventory (could take hours)
+5. Update order status
+
+Without orchestration primitives, this is a nightmare of queues, timers, and state tracking spread across multiple services. With DTFx, it looks like this:
+
+```csharp
+[DurableTask]
+public class OrderFulfillmentOrchestration : TaskOrchestrator<OrderInput, OrderResult>
+{
+    public override async Task<OrderResult> RunAsync(
+        TaskOrchestrationContext context, OrderInput order)
+    {
+        // Step 1: Verify payment — retries on transient failure
+        var paymentResult = await context.CallActivityAsync<PaymentResult>(
+            nameof(VerifyPaymentActivity), order,
+            new TaskOptions { Retry = new RetryPolicy(maxRetries: 3, firstRetryInterval: TimeSpan.FromSeconds(5)) });
+
+        if (!paymentResult.Success)
+            return OrderResult.PaymentFailed(paymentResult.Reason);
+
+        // Step 2: Fan out notifications in parallel
+        var tasks = new[]
+        {
+            context.CallActivityAsync(nameof(NotifyWarehouseActivity), order),
+            context.CallActivityAsync(nameof(NotifyShippingActivity), order),
+            context.CallActivityAsync(nameof(NotifyAnalyticsActivity), order),
+        };
+        await Task.WhenAll(tasks);
+
+        // Step 3: Wait for external inventory confirmation — could be hours, no polling
+        var confirmation = await context.WaitForExternalEventAsync<InventoryConfirmation>(
+            "InventoryConfirmed",
+            timeout: TimeSpan.FromHours(48));
+
+        return OrderResult.Fulfilled(confirmation.EstimatedShipDate);
+    }
+}
+```
+
+Read that again. That `WaitForExternalEventAsync` call — your process can sleep for 48 hours waiting for that event, and if the host crashes while waiting, when it comes back up the orchestration resumes exactly where it left off. No polling. No stored timer records. No "check if we have a pending approval row in the database." The framework reconstructs the orchestration's state by replaying the history.
+
+This is the bit that took me a minute to fully appreciate. The code looks synchronous and simple. Under the hood, the framework is storing every step as an event log and replaying that log to reconstruct state. It's event sourcing, but you never write the event sourcing code.
+
+---
+
+## The Part I Glossed Over: DTFx vs. Durable Functions vs. Durable Task SDKs
+
+Okay, this is where the naming gets a little confusing, and I want to untangle it properly because I definitely got confused.
+
+- **DTFx (Durable Task Framework)** — the original, community-maintained open-source library. Think of it as the core engine. Powerful, battle-tested (Microsoft's own teams use it in production), but community-supported rather than Microsoft-supported.
+
+- **Durable Functions** — Azure Functions' hosted orchestration experience. Built on DTFx under the hood. If you're already in the Functions world, this is the natural path. Full Microsoft support, tight Functions integration.
+
+- **Durable Task SDKs** — the modern, officially-supported, polyglot evolution. Available for .NET, Python, Java, and JavaScript/TypeScript. These work on *any compute* — Azure Container Apps, AKS, VMs, your laptop. Not tied to Azure Functions at all.
+
+- **Azure Durable Task Scheduler** — the managed Azure backend for the Durable Task SDKs and Durable Functions. Think of it as "we run the hard orchestration infrastructure, you just run your app."
+
+For a new project? Start with the **Durable Task SDKs + Azure Durable Task Scheduler**. You get official Microsoft support, a built-in dashboard, multi-language support, and you're not locked to Functions hosting. That's the stack I'll focus on for the rest of this post.
+
+---
+
+## Why the Scheduler Changes Things
+
+When I say "managed backend," I don't want that to sound boring. Here's what it actually means.
+
+In the old DIY world of running DTFx yourself, you had to provision storage (Service Bus queues, Azure Storage accounts, or a SQL database), manage connection strings, deal with partition management overhead consuming your app's CPU, and figure out how to observe what's actually happening in your orchestrations.
+
+The **Azure Durable Task Scheduler** is a purpose-built Azure resource (`Microsoft.DurableTask/schedulers`) that takes all of that away:
+
+**No polling.** Work items are pushed to your app over a gRPC connection. Your app isn't burning cycles asking "anything for me?" — the scheduler pushes work the moment it's ready.
+
+**No storage account to manage.** State lives inside the scheduler resource. Highly optimized for this exact use case. Lower latency, better durability, less operational noise.
+
+**A dashboard that actually ships with the product.** Not "here's how to hook up Azure Monitor and build some queries." An actual UI, out of the box, where you can see all your orchestration instances, drill into their history, see what steps ran, how long each activity took, and perform management operations like pausing or terminating a stuck workflow.
+
+**Task hubs for isolation.** One scheduler resource, multiple task hubs — one per environment, one per team, whatever makes sense. They share the scheduler's resources but stay logically isolated.
+
+And for local development: a **Docker emulator** that runs the full scheduler locally. No Azure subscription needed to iterate.
+
+```bash
+docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 \
+  mcr.microsoft.com/dts/dts-emulator:latest
+```
+
+That's it. Full local scheduler, with the same dashboard UI, pointing at `http://localhost:8082`.
+
+---
+
+## Getting Started: A Real Code Walkthrough
+
+Let me show you a minimal but complete example using the .NET SDK. We're building a fan-out/fan-in orchestration — kick off a bunch of parallel tasks, wait for all of them, aggregate the results. Classic pattern, surprisingly painful to implement yourself.
+
+**Install the packages:**
+
+```bash
+dotnet add package Microsoft.DurableTask.Worker.AzureManaged
+dotnet add package Microsoft.DurableTask.Client.AzureManaged
+```
+
+**Define the orchestration and activities:**
+
+```csharp
+// The orchestration — runs on the worker, coordinates everything
+[DurableTask]
+public class BatchProcessingOrchestration : TaskOrchestrator<string[], BatchResult>
+{
+    public override async Task<BatchResult> RunAsync(
+        TaskOrchestrationContext context, string[] items)
+    {
+        context.SetCustomStatus("Processing started");
+
+        // Fan out: kick off one activity per item, all in parallel
+        var tasks = items.Select(item =>
+            context.CallActivityAsync<ItemResult>(
+                nameof(ProcessItemActivity), item));
+
+        var results = await Task.WhenAll(tasks);
+
+        // Fan in: aggregate
+        return new BatchResult
+        {
+            ProcessedCount = results.Length,
+            SuccessCount = results.Count(r => r.Success),
+            TotalDuration = results.Sum(r => r.ProcessingMs)
+        };
+    }
+}
+
+// An activity — the unit of work, runs independently
+[DurableTask]
+public class ProcessItemActivity : TaskActivity<string, ItemResult>
+{
+    public override async Task<ItemResult> RunAsync(
+        TaskActivityContext context, string item)
+    {
+        // Your actual work here — call an API, process a record, whatever
+        await Task.Delay(Random.Shared.Next(100, 500)); // simulate real work
+        return new ItemResult { Item = item, Success = true, ProcessingMs = 250 };
+    }
+}
+```
+
+**Wire up the worker (Program.cs):**
+
+```csharp
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddDurableTaskWorker(workerBuilder =>
+{
+    workerBuilder.AddTasks<BatchProcessingOrchestration>();
+    workerBuilder.AddTasks<ProcessItemActivity>();
+    
+    // Uses emulator by default if no env vars set — production uses Azure
+    workerBuilder.UseAzureManaged();
+});
+
+builder.Services.AddDurableTaskClient(clientBuilder =>
+{
+    clientBuilder.UseAzureManaged();
+});
+
+var host = builder.Build();
+await host.RunAsync();
+```
+
+**Schedule an orchestration from the client:**
+
+```csharp
+var client = host.Services.GetRequiredService<DurableTaskClient>();
+
+var items = new[] { "Item1", "Item2", "Item3", "Item4", "Item5" };
+var instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+    nameof(BatchProcessingOrchestration), items);
+
+Console.WriteLine($"Started orchestration: {instanceId}");
+
+// Wait for it to complete
+var result = await client.WaitForInstanceCompletionAsync(instanceId);
+Console.WriteLine($"Completed: {result.SerializedOutput}");
+```
+
+Run the emulator first, then start the worker and client. Open `http://localhost:8082` in your browser and watch the orchestration run through the dashboard. See each activity start and complete in real time. That's not a demo rig — that's what your production setup looks like too.
+
+---
+
+## When Should You Reach for This?
+
+Not everything needs orchestration. Simple queue-consumer patterns work fine. But if you find yourself building any of these, stop and look at Durable Task first:
+
+**Long-running processes that need to survive restarts.** Data pipeline that takes hours. Approval workflows waiting on humans. Anything where "the host died, start over" is not acceptable.
+
+**Fan-out/fan-in with real parallelism.** You need to spin up 50 parallel tasks, collect all their results, and make a decision. Doing this with a message queue and a correlation ID table works, but it's annoying to build and annoying to debug. Durable Task makes it three lines of code.
+
+**Workflows with complex error handling and retries.** Built-in retry policies with exponential backoff, per-activity. Automatic state persistence means a retry doesn't re-run everything from scratch — it picks up from the last successful checkpoint.
+
+**External event integration.** "Wait until a human approves this" or "wait until the webhook fires" or "wait up to 72 hours for a payment confirmation." Without orchestration, this is a timer + database row + polling loop. With Durable Task, it's `WaitForExternalEventAsync`.
+
+**Multi-agent orchestration.** This one is increasingly relevant. If you're building AI workflows where Agent A kicks off work, waits for Agent B and Agent C to finish in parallel, collects their outputs, and feeds them to Agent D — that's exactly what Durable Task is designed for. The framework already powers a lot of the infrastructure behind Semantic Kernel's process orchestration features.
+
+---
+
+## The Thing I Wish Someone Had Told Me
+
+Here's my honest take after spending real time with this stack: the hardest part isn't the framework. The framework is excellent. The hardest part is accepting that you don't need to build the orchestration infrastructure yourself.
+
+I spent years writing bespoke workflow engines. Queues and state machines and compensation tables and checkpoint logic. And I'm not saying that experience was wasted — understanding what the framework is doing underneath makes you use it better. But at some point, "I could build this myself" stops being a reason to do so.
+
+The Durable Task Scheduler is a managed service that Microsoft's own engineering teams use in production. The Durable Task SDKs are officially supported, actively developed, and available in four languages. The local emulator ships a full dashboard. The pricing model has both dedicated and consumption tiers.
+
+This is a production-ready, fully-supported, genuinely well-designed piece of infrastructure. The fact that it's not in every architecture conversation is the thing I can't explain.
+
+So here's my challenge to you: next time you're about to draw a state machine on a whiteboard and figure out which queue goes where — look at Durable Task first. Spend 30 minutes with the quickstart. Run the emulator locally. Open the dashboard.
+
+I'll bet the whiteboard stays clean.
+
+---
+
+## Quick Reference
+
+| What you want | What to use |
+|---|---|
+| Serverless, Azure Functions hosting | Durable Functions |
+| Any compute (.NET, Python, Java, JS) | Durable Task SDKs |
+| Managed backend + dashboard | Azure Durable Task Scheduler |
+| Local development | Docker emulator (`mcr.microsoft.com/dts/dts-emulator`) |
+
+**Useful links:**
+
+- [Durable Task SDKs overview](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-overview)
+- [Azure Durable Task Scheduler docs](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler)
+- [Quickstart: Fan-out/fan-in with Durable Task SDKs](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/quickstart-portable-durable-task-sdks)
+- [Sample code repository (Azure-Samples/Durable-Task-Scheduler)](https://github.com/Azure-Samples/Durable-Task-Scheduler)
+- [Original DTFx repo (Azure/durabletask)](https://github.com/Azure/durabletask)
+
+---
+
+## Demo Repo
+
+> **Demo repo: [TBD — to be built]**
+>
+> I'm building a companion repo that walks through a realistic end-to-end scenario: an order processing workflow with payment verification, parallel notifications, a human approval step, and full observability via the Durable Task Scheduler dashboard. Watch this space (or the GitHub issue) for the link when it's ready.
+
+---
+
+*Have you used Durable Task in production? I'd love to hear what patterns you've hit and what tripped you up. Find me on [GitHub](https://github.com/tamirdresher) or [LinkedIn](https://linkedin.com/in/tamirdresher).*

--- a/_posts/2026-04-10-durable-task-scheduler.md
+++ b/_posts/2026-04-10-durable-task-scheduler.md
@@ -388,7 +388,7 @@ And now that same rigor — the same battle-tested engine that Microsoft uses in
 
 The cosmic joke keeps getting funnier.
 
-You can see the whole picture in the [Durable Task Scheduler dashboard](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler). Same observability, same metrics, whether you're orchestrating payment flows or AI reasoning chains.
+You can see the whole picture in the [Durable Task Scheduler dashboard](https://learn.microsoft.com/en-us/azure/durable-task/scheduler/durable-task-scheduler-dashboard?pivots=az-cli#monitor-orchestration-progress-and-execution-history). Same observability, same metrics, whether you're orchestrating payment flows or AI reasoning chains.
 
 Supports C# (.NET 8.0+) and Python (3.10+) with Azure Functions. Runs anywhere Azure Functions runs. Scales like Azure Functions scales.
 

--- a/_posts/2026-04-10-durable-task-scheduler.md
+++ b/_posts/2026-04-10-durable-task-scheduler.md
@@ -311,52 +311,9 @@ Good question. I think it's a combination of factors:
 
 But once you get past these hurdles, this is **the** way to build reliable workflows in .NET. It's not just for Azure. It's not just for serverless. It's a general-purpose orchestration framework that happens to have a world-class managed backend option.
 
----
 
-## The Honest Reality
 
-This isn't a silver bullet. There are scenarios where Hangfire or Quartz.NET is still the right choice:
 
-- **Use Hangfire if**: You need simple fire-and-forget jobs with a nice dashboard, and you're okay with your database as a queue.
-- **Use Quartz.NET if**: You need complex cron scheduling, enterprise clustering, and precise timing guarantees.
-- **Use Durable Task Framework if**: You need workflows — multi-step processes with state, retries, compensation, external events, or anything that could run longer than a few minutes.
-
-But if you're building a system where you're manually stitching together background jobs into workflows, tracking state in your database, and writing custom retry logic? You're reinventing the Durable Task Framework. Stop. Use the thing that's already built and battle-tested.
-
----
-
-## Getting Started
-
-Here's the fastest path to trying this out:
-
-### 1. **Start with Durable Functions** (easiest)
-If you're new to this, start with Durable Functions. It's the fastest way to see the orchestration model in action:
-
-```bash
-# Create a new Durable Functions app
-func init MyDurableFunctionsApp --worker-runtime dotnet-isolated
-cd MyDurableFunctionsApp
-func new --template "Durable Functions orchestration" --name OrderWorkflow
-
-# Run it locally
-func start
-```
-
-Microsoft's [Durable Functions quickstart](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-create-first-csharp) is excellent.
-
-### 2. **Try the Durable Task SDK** (for self-hosting)
-If you want to run outside Azure Functions, check out the [Durable Task SDK samples](https://github.com/Azure/durabletask):
-
-```bash
-git clone https://github.com/Azure/durabletask.git
-cd durabletask/samples
-dotnet run
-```
-
-### 3. **Explore Durable Task Scheduler** (managed backend)
-The Durable Task Scheduler is in GA for dedicated SKU and public preview for consumption SKU. Check out the [official docs](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler) for setup instructions.
-
----
 
 ## Where I See This Fitting
 
@@ -368,9 +325,81 @@ Having lived through building a production Conductor deployment at Payoneer — 
 
 3. **Human-in-the-loop workflows**: Orchestrations that wait for approval with timeout escalations — a first-class pattern. The framework doesn't care if it waits five minutes or five days. No queue starvation debugging required.
 
-4. **AI agent orchestration**: This is the one that broke my brain a little. The **[Microsoft Agent Framework](https://github.com/microsoft/agent-framework)** has a [durable task extension](https://learn.microsoft.com/en-us/agent-framework/integrations/azure-functions) for building stateful AI agents and multi-agent workflows. Same checkpointing. Same fault tolerance. Same scaling patterns. The technology I used for "don't accidentally charge someone twice" now solves "don't lose your AI agent's reasoning mid-conversation." I wrote about this framework in 2017. I built workflow orchestration at Payoneer. And now the same underlying tech is coordinating AI agents. The cosmic joke keeps getting funnier.
+4. **AI agent orchestration**: The Microsoft Agent Framework runs on this same engine (see "The Cosmic Joke Continues" below). Same orchestration primitives solving entirely different problems.
 
 If I were starting that Payoneer project today with a .NET stack? I'd absolutely evaluate the Durable Task Framework with the Scheduler backend. The code-first approach maps to how .NET developers already think. And I wouldn't have to tune Redis fsync intervals at 2 AM.
+
+---
+
+## The Cosmic Joke Continues
+
+Remember when I said this technology has been quietly growing up? Here's the part that broke my brain a little.
+
+In January 2026, Microsoft announced the **[durable task extension for the Microsoft Agent Framework](https://techcommunity.microsoft.com/blog/appsonazureblog/bulletproof-agents-with-the-durable-task-extension-for-microsoft-agent-framework/4467122)** is now in public preview. And it brings exactly what you'd expect: durable execution, distributed execution, fault tolerance — except instead of orchestrating payment workflows, it's orchestrating **AI agents**.
+
+Same engine. Same checkpointing model. Same "write it like regular code" pattern. But now it's solving:
+
+- "Don't lose the agent's reasoning mid-conversation if the server crashes"
+- "Pause for human input without burning serverless compute for hours"
+- "Coordinate multiple specialized agents with predictable, repeatable execution"
+- "Scale from thousands of concurrent agent sessions to zero"
+
+Microsoft calls it the **4D's**: Durable, Distributed, Deterministic, Developer-friendly.
+
+That last one is not marketing speak. Look at the Python example:
+
+```python
+from agent_framework.agents import Agent
+from agent_framework.azure_functions import AgentFunctionApp
+
+agent = Agent(
+    id="my-agent",
+    model="gpt-4",
+    instructions="You are a helpful assistant."
+)
+
+app = AgentFunctionApp(agents=[agent])
+```
+
+That's it. That's a durable AI agent with automatic session management, crash recovery, and distributed execution. The framework handles persistence. The Durable Task Scheduler backend handles scaling. You write agent logic.
+
+The C# version is equally clean:
+
+```csharp
+builder.Services
+    .AddDurableAgents()
+    .ConfigureDurableAgents(options =>
+    {
+        options.AddAgent("my-agent", agent =>
+        {
+            agent.UseAzureOpenAI("gpt-4");
+            agent.WithInstructions("You are a helpful assistant.");
+        });
+    });
+```
+
+Under the hood, each agent is implemented as a **durable entity** — a stateful actor that maintains conversation context across executions. The same technology that made payment workflows survive process crashes now makes AI agents survive them. The same fan-out patterns I used for batch processing now coordinate specialized agents (one for research, one for code generation, one for fact-checking).
+
+And the human-in-the-loop pattern I showed earlier? That's a first-class feature now. An agent can wait for a user to reply, costing you nothing while it waits, then resume exactly where it left off. Try building that yourself with raw OpenAI API calls and tell me how your state management is going.
+
+Here's the thing that makes me laugh: at Payoneer, we spent months building reliability patterns into workflow orchestration. Queue starvation debugging. Checkpoint-and-replay validation. Idempotency guarantees. Because financial transactions don't get second chances.
+
+And now that same rigor — the same battle-tested engine that Microsoft uses internally at massive scale — is what makes AI agents reliable enough for production. The technology I wrote about in 2017 for serverless workflows is now powering agent frameworks. The problems we solved at Payoneer ("survive crashes," "coordinate parallel work," "wait indefinitely without wasting resources") are the exact problems AI agent systems face.
+
+The cosmic joke keeps getting funnier.
+
+You can see the whole picture in the [Durable Task Scheduler dashboard](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler). Same observability, same metrics, whether you're orchestrating payment flows or AI reasoning chains.
+
+Supports C# (.NET 8.0+) and Python (3.10+) with Azure Functions. Runs anywhere Azure Functions runs. Scales like Azure Functions scales.
+
+If you're building multi-agent systems or just want your AI agent to survive a server restart without losing its train of thought, this is worth a serious look:
+- [Official announcement](https://techcommunity.microsoft.com/blog/appsonazureblog/bulletproof-agents-with-the-durable-task-extension-for-microsoft-agent-framework/4467122)
+- [Agent Framework docs](https://learn.microsoft.com/en-us/agent-framework/integrations/azure-functions)
+- [Durable extension overview](https://aka.ms/durable-extension-for-af)
+- [C# samples](https://aka.ms/durable-extension-csharp-samples)
+- [Python samples](https://aka.ms/durable-extension-python-samples)
+
+Same framework. Different problems. All the way down.
 
 ---
 
@@ -386,10 +415,18 @@ Use the framework that Microsoft built, open-sourced, and uses internally at sca
 
 **Want to dive deeper?** Here are the resources I wish someone had handed me earlier:
 
+**Core Durable Task Resources:**
 - [What is Durable Task? (Official Docs)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/what-is-durable-task)
 - [Durable Task Framework GitHub](https://github.com/Azure/durabletask)
 - [Durable Task Scheduler Docs](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler)
 - [Durable Functions Patterns](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview?tabs=in-process%2Cnodejs-v3%2Cv1-model&pivots=csharp)
+
+**Agent Framework Integration:**
+- [Bulletproof Agents announcement](https://techcommunity.microsoft.com/blog/appsonazureblog/bulletproof-agents-with-the-durable-task-extension-for-microsoft-agent-framework/4467122)
+- [Agent Framework + Durable Task docs](https://learn.microsoft.com/en-us/agent-framework/integrations/azure-functions)
+- [Durable extension overview](https://aka.ms/durable-extension-for-af)
+- [C# samples](https://aka.ms/durable-extension-csharp-samples)
+- [Python samples](https://aka.ms/durable-extension-python-samples)
 
 If you're already using this and I've missed something important, or if you have your own workflow orchestration war stories (Conductor, Temporal, Hangfire, home-grown state machines — I've seen them all), I'd love to hear them. Find me on [Twitter/X](https://twitter.com/tamirdresher) or [LinkedIn](https://www.linkedin.com/in/tamirdresher).
 

--- a/_posts/2026-04-10-durable-task-scheduler.md
+++ b/_posts/2026-04-10-durable-task-scheduler.md
@@ -19,7 +19,7 @@ Conductor was the right call. DSL-based, language-agnostic, proven at Netflix sc
 
 But here's the thing that makes me laugh now: while I was tuning Redis persistence modes and writing custom event bridges and debugging why a single slow HTTP Task response would starve an entire queue — **the technology I wrote about in 2017 was quietly growing up**.
 
-The Durable Task Framework evolved from a beta curiosity into a standalone SDK. First-class support for .NET, Python, Java, JavaScript. Battle-tested at Microsoft scale. And now? Microsoft launched the **Durable Task Scheduler** as a fully managed Azure service.
+The Durable Task Framework evolved from a beta curiosity into a standalone SDK. First-class support for .NET, Python, Java, JavaScript. Battle-tested at Microsoft scale. And now? Microsoft launched the **Durable Task Scheduler** as a fully managed Azure service — and the same engine is [powering AI agent orchestrations](https://learn.microsoft.com/en-us/agent-framework/integrations/azure-functions) in the **Microsoft Agent Framework**. Because of course it is.
 
 It solves **exactly** the problems I spent months wrestling with at Payoneer. The queue starvation? Built-in activity queues per task type. The Redis memory footprint from storing workflow definitions in every instance? Managed state. The idempotency concerns? Checkpointing model handles it. The worker SDK complexity? Just write C# that looks like regular async code.
 
@@ -158,6 +158,7 @@ Great question. Here's the thing: **Durable Functions IS built on the Durable Ta
 - You need complete control over hosting and scaling
 - You're building a hybrid or multi-cloud solution
 - You have an existing .NET app and want to add workflow orchestration without Azure Functions
+- You're building AI agent systems that need durable state management (yes, [the Microsoft Agent Framework does exactly this](https://learn.microsoft.com/en-us/agent-framework/integrations/azure-functions))
 
 The framework is **open source** (https://github.com/Azure/durabletask). You can run it anywhere. You can use Azure Storage, SQL Server, or the new **Durable Task Scheduler** as the backend.
 
@@ -366,6 +367,8 @@ Having lived through building a production Conductor deployment at Payoneer — 
 2. **Fan-out/fan-in at scale**: What we built with custom worker SDKs and bulk processing logic becomes 50 lines of orchestration code. The coordination that required careful queue management? Built in.
 
 3. **Human-in-the-loop workflows**: Orchestrations that wait for approval with timeout escalations — a first-class pattern. The framework doesn't care if it waits five minutes or five days. No queue starvation debugging required.
+
+4. **AI agent orchestration**: This is the one that broke my brain a little. The **[Microsoft Agent Framework](https://github.com/microsoft/agent-framework)** has a [durable task extension](https://learn.microsoft.com/en-us/agent-framework/integrations/azure-functions) for building stateful AI agents and multi-agent workflows. Same checkpointing. Same fault tolerance. Same scaling patterns. The technology I used for "don't accidentally charge someone twice" now solves "don't lose your AI agent's reasoning mid-conversation." I wrote about this framework in 2017. I built workflow orchestration at Payoneer. And now the same underlying tech is coordinating AI agents. The cosmic joke keeps getting funnier.
 
 If I were starting that Payoneer project today with a .NET stack? I'd absolutely evaluate the Durable Task Framework with the Scheduler backend. The code-first approach maps to how .NET developers already think. And I wouldn't have to tune Redis fsync intervals at 2 AM.
 

--- a/_posts/2026-04-10-durable-task-scheduler.md
+++ b/_posts/2026-04-10-durable-task-scheduler.md
@@ -2,7 +2,7 @@
 layout: post
 title: "This Is the Best Framework and Azure Service You're Probably Not Using"
 date: 2026-04-10
-tags: [azure, durable-task-framework, durable-functions, orchestration, workflows, background-jobs, dotnet]
+tags: [azure, durable-task-sdk, durable-task-scheduler, durable-functions, orchestration, workflows, background-jobs, dotnet]
 ---
 
 I've been circling this technology for almost a decade. Stick with me.
@@ -19,7 +19,7 @@ Conductor was the right call. DSL-based, language-agnostic, proven at Netflix sc
 
 But here's the thing that makes me laugh now: while I was tuning Redis persistence modes and writing custom event bridges and debugging why a single slow HTTP Task response would starve an entire queue — **the technology I wrote about in 2017 was quietly growing up**.
 
-The Durable Task Framework evolved from a beta curiosity into a standalone SDK. First-class support for .NET, Python, Java, JavaScript. Battle-tested at Microsoft scale. And now? Microsoft launched the **Durable Task Scheduler** as a fully managed Azure service — and the same engine is [powering AI agent orchestrations](https://learn.microsoft.com/en-us/agent-framework/integrations/azure-functions) in the **Microsoft Agent Framework**. Because of course it is.
+The Durable Task engine evolved from a beta curiosity into a family of modern **Durable Task SDKs** — .NET, Python, Java, JavaScript, and soon Go. (Don't confuse these with the original [Durable Task Framework](https://github.com/azure/durabletask), which is the legacy .NET-only predecessor.) Battle-tested at Microsoft scale. And now? Microsoft launched the **Durable Task Scheduler** as a fully managed Azure service — a backend that works with *both* Durable Functions and the standalone Durable Task SDKs — and the same engine is [powering AI agent orchestrations](https://learn.microsoft.com/en-us/agent-framework/integrations/azure-functions) in the **Microsoft Agent Framework**. Because of course it is.
 
 It solves **exactly** the problems I spent months wrestling with at Payoneer. The queue starvation? Built-in activity queues per task type. The Redis memory footprint from storing workflow definitions in every instance? Managed state. The idempotency concerns? Checkpointing model handles it. The worker SDK complexity? Just write C# that looks like regular async code.
 
@@ -27,7 +27,7 @@ You can't make this stuff up.
 
 And here's the weirdest part: **almost nobody knows this exists.**
 
-I talk to .NET developers all the time. They know Azure Functions. They've heard of Durable Functions. But mention "Durable Task Framework" or "Durable Task Scheduler" and I get blank stares. Which is *wild*, because this is the exact same engine powering Durable Functions under the hood. It's open source. It's battle-tested at massive scale. It solves problems that every distributed system eventually faces.
+I talk to .NET developers all the time. They know Azure Functions. They've heard of Durable Functions. But mention "Durable Task SDKs" or "Durable Task Scheduler" and I get blank stares. Which is *wild*, because this is the exact same engine powering Durable Functions under the hood. It's open source. It works in .NET, Python, Java, JavaScript, and soon Go. It solves problems that every distributed system eventually faces.
 
 So let me tell you about the best framework and Azure service you're probably not using.
 
@@ -166,23 +166,21 @@ The framework is **open source** (https://github.com/Azure/durabletask). You can
 
 ## Enter the Durable Task Scheduler: The Missing Piece
 
-Here's where it gets really good. Microsoft recently launched the **Durable Task Scheduler** as a fully managed Azure service. Think of it as the orchestration engine extracted into its own service.
+Here's where it gets really good. Microsoft recently launched the **Durable Task Scheduler** as a fully managed Azure service. Think of it as the orchestration engine extracted into its own managed backend.
 
-Before, if you wanted to run orchestrations, you had two choices:
-1. **Azure Functions** (managed, but tightly coupled to Functions runtime)
-2. **Self-hosted** (flexible, but you manage storage, scaling, monitoring)
+The story is actually pretty clean now: it doesn't matter where you're hosting your workloads.
 
-Now there's a third option: **Durable Task Scheduler**.
+If you're on **Azure Functions**, you can use the **Durable Functions extension** — same programming model you already know — and point it at the Durable Task Scheduler instead of Azure Storage, SQL, or Netherite. You get managed state, automatic scaling, and built-in dashboards without changing how you write orchestrations.
 
-It's a managed backend that handles:
+If you're running on **containers, VMs, or Kubernetes**, you use the **[Durable Task SDKs](https://github.com/microsoft/durabletask-dotnet)** directly — available for .NET, Python, Java, JavaScript, and soon Go. Same engine, same reliability guarantees, no Azure Functions dependency.
+
+Either way, the Durable Task Scheduler handles:
 - State persistence (no need to configure storage accounts)
 - Automatic scaling (handles millions of orchestrations)
-- Monitoring and diagnostics (built-in dashboards)
+- Monitoring and diagnostics ([built-in dashboards](https://learn.microsoft.com/en-us/azure/durable-task/scheduler/durable-task-scheduler-dashboard?pivots=az-cli#monitor-orchestration-progress-and-execution-history))
 - Fault tolerance (orchestrations survive failures)
 
-You write code against the Durable Task SDK, point it at the Durable Task Scheduler, and you get all the benefits of a managed service without being locked into Azure Functions.
-
-Here's what that looks like:
+Here's what the standalone SDK approach looks like:
 
 ```csharp
 var builder = new HostBuilder()
@@ -287,7 +285,7 @@ The orchestration can literally wait for days for a user to click a button. The 
 A side-by-side comparison showing the same workflow implemented with:
 - Hangfire (manual state, queuing, retry logic)
 - Quartz.NET (cron-based, not workflow-friendly)
-- Durable Task Framework (clean, declarative)
+- Durable Task SDK (clean, declarative)
 
 ### 5. **Deployment Examples**
 How to run this on:
@@ -301,15 +299,15 @@ How to run this on:
 
 Good question. I think it's a combination of factors:
 
-1. **Naming Confusion**: "Durable Functions," "Durable Task Framework," "Durable Task Scheduler" — people think they're all the same thing or don't understand the differences.
+1. **Naming Confusion**: "Durable Functions," "Durable Task Framework," "Durable Task SDKs," "Durable Task Scheduler" — it's a lot of "Durable" and people either think they're all the same thing or give up trying to untangle them. Here's the cheat sheet: **Durable Task Framework** is the legacy .NET-only predecessor. The modern **Durable Task SDKs** are multi-language and what you should use today. **Durable Functions** uses the same engine inside Azure Functions. And **Durable Task Scheduler** is the managed backend that any of them can use.
 
-2. **Hidden in Plain Sight**: Most developers encounter Durable Functions first and assume that's the only way to use this pattern. They don't realize the underlying framework is available independently.
+2. **Hidden in Plain Sight**: Most developers encounter Durable Functions first and assume that's the only way to use this pattern. They don't realize the underlying engine is available as standalone SDKs for .NET, Python, Java, JavaScript, and soon Go — no Functions runtime required.
 
 3. **Perceived Complexity**: The async/await orchestration model looks weird the first time you see it. "Wait, I can just `await` a 30-minute timer? That doesn't make sense!" (It does. It's brilliant.)
 
 4. **Documentation Fragmentation**: Microsoft's docs are getting better, but there's still a lot of "if you want X, read this doc; if you want Y, read that doc; if you want Z, good luck."
 
-But once you get past these hurdles, this is **the** way to build reliable workflows in .NET. It's not just for Azure. It's not just for serverless. It's a general-purpose orchestration framework that happens to have a world-class managed backend option.
+But once you get past these hurdles, this is **the** way to build reliable workflows. Durable Functions for Azure Functions. Durable Task SDKs for everything else. Both can leverage the Durable Task Scheduler as a managed backend. It's not just for Azure. It's not just for serverless. It's a general-purpose orchestration engine that happens to have a world-class managed backend option.
 
 
 
@@ -317,7 +315,7 @@ But once you get past these hurdles, this is **the** way to build reliable workf
 
 ## Where I See This Fitting
 
-Having lived through building a production Conductor deployment at Payoneer — tuning Redis persistence, debugging queue starvation, writing custom worker SDKs for hundreds of thousands of concurrent workflows — I can tell you exactly where the Durable Task Framework shines.
+Having lived through building a production Conductor deployment at Payoneer — tuning Redis persistence, debugging queue starvation, writing custom worker SDKs for hundreds of thousands of concurrent workflows — I can tell you exactly where the Durable Task SDKs shine.
 
 The first place my brain goes is multi-step payment processing. The exact stuff we were doing at Payoneer. Same fan-out patterns, same retry semantics, same survival guarantees. But here's the thing — instead of learning a DSL and maintaining separate workflow definitions in JSON or YAML, you just write plain C# that looks like regular async code. That alone would have saved us weeks of onboarding new developers who had to learn Conductor's definition model before they could touch a workflow.
 
@@ -327,7 +325,7 @@ Human-in-the-loop workflows are where it gets really elegant. Orchestrations tha
 
 And then — because the universe apparently has a sense of humor about my career — there's AI agent orchestration. The Microsoft Agent Framework runs on this same engine (see "The Cosmic Joke Continues" below). Same orchestration primitives, same durable execution model, solving entirely different problems. The workflow engine I needed for payments in 2019 is now powering AI agents in 2026. I genuinely couldn't have predicted that.
 
-If I were starting that Payoneer project today with a .NET stack? I'd absolutely evaluate the Durable Task Framework with the Scheduler backend. The code-first approach maps to how .NET developers already think. And I wouldn't have to tune Redis fsync intervals at 2 AM.
+If I were starting that Payoneer project today with a .NET stack? I'd absolutely evaluate the Durable Task SDKs with the Scheduler backend. The code-first approach maps to how .NET developers already think. And I wouldn't have to tune Redis fsync intervals at 2 AM.
 
 ---
 
@@ -390,7 +388,7 @@ The cosmic joke keeps getting funnier.
 
 You can see the whole picture in the [Durable Task Scheduler dashboard](https://learn.microsoft.com/en-us/azure/durable-task/scheduler/durable-task-scheduler-dashboard?pivots=az-cli#monitor-orchestration-progress-and-execution-history). Same observability, same metrics, whether you're orchestrating payment flows or AI reasoning chains.
 
-Supports C# (.NET 8.0+) and Python (3.10+) with Azure Functions. Runs anywhere Azure Functions runs. Scales like Azure Functions scales.
+Supports C# (.NET 8.0+) and Python (3.10+) with Azure Functions — and .NET, Python, Java, JavaScript, and soon Go via the standalone SDKs. Runs anywhere. Scales as far as you need.
 
 If you're building multi-agent systems or just want your AI agent to survive a server restart without losing its train of thought, this is worth a serious look:
 - [Official announcement](https://techcommunity.microsoft.com/blog/appsonazureblog/bulletproof-agents-with-the-durable-task-extension-for-microsoft-agent-framework/4467122)
@@ -405,7 +403,7 @@ Same framework. Different problems. All the way down.
 
 ## The Bottom Line
 
-If you're building distributed systems in .NET, you need to know about the Durable Task Framework and Durable Task Scheduler. It's not a niche tool. It's not just for Azure Functions. It's a fundamental pattern for reliable workflows that happens to have first-class support in Azure.
+If you're building distributed systems, you need to know about the Durable Task SDKs and Durable Task Scheduler. It's not a niche tool. It's not just for Azure Functions. It's a fundamental pattern for reliable workflows — in .NET, Python, Java, JavaScript, and soon Go — that happens to have first-class support in Azure.
 
 Stop manually building orchestrations with job queues and database tables. Stop writing custom retry logic. Stop reinventing the wheel.
 
@@ -417,8 +415,10 @@ Use the framework that Microsoft built, open-sourced, and uses internally at sca
 
 **Core Durable Task Resources:**
 - [What is Durable Task? (Official Docs)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/what-is-durable-task)
-- [Durable Task Framework GitHub](https://github.com/Azure/durabletask)
+- [Durable Task .NET SDK (Modern)](https://github.com/microsoft/durabletask-dotnet) — .NET, Python, Java, JS, soon Go
+- [Durable Task Framework (Legacy, .NET only)](https://github.com/Azure/durabletask)
 - [Durable Task Scheduler Docs](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler)
+- [Durable Task Scheduler Dashboard](https://learn.microsoft.com/en-us/azure/durable-task/scheduler/durable-task-scheduler-dashboard?pivots=az-cli#monitor-orchestration-progress-and-execution-history)
 - [Durable Functions Patterns](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview?tabs=in-process%2Cnodejs-v3%2Cv1-model&pivots=csharp)
 
 **Agent Framework Integration:**

--- a/_posts/2026-04-10-durable-task-scheduler.md
+++ b/_posts/2026-04-10-durable-task-scheduler.md
@@ -23,7 +23,7 @@ The Durable Task Framework evolved from a beta curiosity into a standalone SDK. 
 
 It solves **exactly** the problems I spent months wrestling with at Payoneer. The queue starvation? Built-in activity queues per task type. The Redis memory footprint from storing workflow definitions in every instance? Managed state. The idempotency concerns? Checkpointing model handles it. The worker SDK complexity? Just write C# that looks like regular async code.
 
-Full circle. Cosmic joke. Pick your metaphor.
+You can't make this stuff up.
 
 And here's the weirdest part: **almost nobody knows this exists.**
 
@@ -317,15 +317,15 @@ But once you get past these hurdles, this is **the** way to build reliable workf
 
 ## Where I See This Fitting
 
-Having lived through building a production Conductor deployment at Payoneer — tuning Redis persistence, debugging queue starvation, writing custom worker SDKs for hundreds of thousands of concurrent workflows — I can tell you exactly where the Durable Task Framework shines:
+Having lived through building a production Conductor deployment at Payoneer — tuning Redis persistence, debugging queue starvation, writing custom worker SDKs for hundreds of thousands of concurrent workflows — I can tell you exactly where the Durable Task Framework shines.
 
-1. **Multi-step payment processing**: The same fan-out patterns, the same retry semantics, the same survival guarantees we needed at Payoneer. Except instead of learning a DSL and maintaining separate workflow definitions, you write it as plain C# that looks like regular async code.
+The first place my brain goes is multi-step payment processing. The exact stuff we were doing at Payoneer. Same fan-out patterns, same retry semantics, same survival guarantees. But here's the thing — instead of learning a DSL and maintaining separate workflow definitions in JSON or YAML, you just write plain C# that looks like regular async code. That alone would have saved us weeks of onboarding new developers who had to learn Conductor's definition model before they could touch a workflow.
 
-2. **Fan-out/fan-in at scale**: What we built with custom worker SDKs and bulk processing logic becomes 50 lines of orchestration code. The coordination that required careful queue management? Built in.
+Then there's fan-out/fan-in at scale. What we built with custom worker SDKs and bulk processing logic — all that careful coordination, the queue management, the "please don't let two workers pick up the same task" prayers — that becomes maybe 50 lines of orchestration code. The hard parts are just... built in. I'm not saying it's trivial. I'm saying the framework absorbed the complexity we had to build ourselves.
 
-3. **Human-in-the-loop workflows**: Orchestrations that wait for approval with timeout escalations — a first-class pattern. The framework doesn't care if it waits five minutes or five days. No queue starvation debugging required.
+Human-in-the-loop workflows are where it gets really elegant. Orchestrations that wait for an approval event with timeout escalations? That's a first-class pattern here. The framework genuinely doesn't care if it waits five minutes or five days. It checkpoints, goes to sleep, wakes up when the signal arrives. No queue starvation debugging required. No "why is this workflow consuming memory while it sits there doing nothing" investigations at midnight.
 
-4. **AI agent orchestration**: The Microsoft Agent Framework runs on this same engine (see "The Cosmic Joke Continues" below). Same orchestration primitives solving entirely different problems.
+And then — because the universe apparently has a sense of humor about my career — there's AI agent orchestration. The Microsoft Agent Framework runs on this same engine (see "The Cosmic Joke Continues" below). Same orchestration primitives, same durable execution model, solving entirely different problems. The workflow engine I needed for payments in 2019 is now powering AI agents in 2026. I genuinely couldn't have predicted that.
 
 If I were starting that Payoneer project today with a .NET stack? I'd absolutely evaluate the Durable Task Framework with the Scheduler backend. The code-first approach maps to how .NET developers already think. And I wouldn't have to tune Redis fsync intervals at 2 AM.
 


### PR DESCRIPTION
## What's in this PR

New blog post: **"The Azure Service I Should Have Been Using For Years (But Wasn't)"**

A deep dive into the Durable Task Framework (DTFx), the Durable Task SDKs, and the Azure Durable Task Scheduler — the underrated orchestration stack that handles fault-tolerant, long-running distributed workflows so you don't have to roll your own.

## Post covers

- What DTFx is and how event-sourcing-based replay works under the hood
- Untangling the naming confusion: DTFx vs. Durable Functions vs. Durable Task SDKs vs. Azure Durable Task Scheduler
- Why the managed Scheduler changes the operational picture (no polling, no storage account to manage, built-in dashboard)
- A complete .NET code walkthrough: fan-out/fan-in orchestration, external event waiting, retry policies
- Running the Docker emulator locally with full dashboard UI
- Decision guide: when to reach for orchestration vs. doing it yourself
- Quick reference table + all the useful links

## File

_posts/2026-04-10-durable-task-scheduler.md

## Related

Tracks issue tamirdresher_microsoft/tamresearch1#2089