### PR TITLE
fix(seo): Update canonical domain to www.tamirdresher.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ description: >-                        # used by seo meta and the atom feed
   Tamir Dresher's blog about .NET, reactive programming, distributed systems, AI, and software architecture. Tips, tools, and insights from a Principal Engineer.
 
 # Replace with the website url, e.g. 'https://username.github.io'
-url: 'https://tamirdresher.github.io'
+url: 'https://www.tamirdresher.com'
 
 author: Tamir Dresher                  # change to your full name
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,9 +20,9 @@
     "@graph": [
       {
         "@type": "Person",
-        "@id": "https://tamirdresher.github.io/#author",
+        "@id": "{{ site.url }}/#author",
         "name": "Tamir Dresher",
-        "url": "https://tamirdresher.github.io",
+        "url": "{{ site.url }}",
         "sameAs": [
           "https://twitter.com/tamir_dresher",
           "https://github.com/tamirdresher",
@@ -33,11 +33,11 @@
       },
       {
         "@type": "WebSite",
-        "@id": "https://tamirdresher.github.io/#website",
-        "url": "https://tamirdresher.github.io",
+        "@id": "{{ site.url }}/#website",
+        "url": "{{ site.url }}",
         "name": "IBlogger — Tamir Dresher",
         "description": "Tamir Dresher's blog about .NET, reactive programming, distributed systems, AI, and software architecture.",
-        "author": { "@id": "https://tamirdresher.github.io/#author" }
+        "author": { "@id": "{{ site.url }}/#author" }
       }
     ]
   }

--- a/tabs/products.md
+++ b/tabs/products.md
@@ -12,11 +12,11 @@ description: "Books, games, and digital products by Tamir Dresher — .NET, reac
   "@type": "CollectionPage",
   "name": "Products & Resources — Tamir Dresher",
   "description": "Books, games, and digital products by Tamir Dresher",
-  "url": "https://tamirdresher.github.io/tabs/products/",
+  "url": "{{ site.url }}/tabs/products/",
   "author": {
     "@type": "Person",
     "name": "Tamir Dresher",
-    "url": "https://tamirdresher.github.io"
+    "url": "{{ site.url }}"
   },
   "hasPart": [
     {


### PR DESCRIPTION
## Summary
Fixes SEO "Page with redirect" issue reported by Google Search Console.

The Jekyll site was generating canonical URLs pointing to `tamirdresher.github.io`
but the live site is at `https://www.tamirdresher.com`. This caused Google to flag
all pages as "Page with redirect", splitting link equity and preventing indexing.

## Changes
- `_config.yml`: Updated `url` to `https://www.tamirdresher.com`
- `_includes/head.html`: Replaced hardcoded GitHub Pages URLs in JSON-LD with `{{ site.url }}`
- `tabs/products.md`: Replaced hardcoded GitHub Pages URLs in JSON-LD with canonical domain
- Any other files with hardcoded `tamirdresher.github.io` URLs

## After merging
1. Verify the live sitemap at `https://www.tamirdresher.com/sitemap.xml` uses the correct domain
2. Re-submit the sitemap in Google Search Console
3. Monitor coverage report for resolution of "Page with redirect" errors

Closes tamirdresher_microsoft/tamresearch1#3594