### PR TITLE
fix(seo): update canonical URL from tamirdresher.github.io to www.tamirdresher.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ description: >-                        # used by seo meta and the atom feed
   Tamir Dresher's blog about .NET, reactive programming, distributed systems, AI, and software architecture. Tips, tools, and insights from a Principal Engineer.
 
 # Replace with the website url, e.g. 'https://username.github.io'
-url: 'https://tamirdresher.github.io'
+url: 'https://www.tamirdresher.com'
 
 author: Tamir Dresher                  # change to your full name
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,9 +20,9 @@
     "@graph": [
       {
         "@type": "Person",
-        "@id": "https://tamirdresher.github.io/#author",
+        "@id": "{{ site.url }}{{ site.baseurl }}/#author",
         "name": "Tamir Dresher",
-        "url": "https://tamirdresher.github.io",
+        "url": "{{ site.url }}{{ site.baseurl }}/",
         "sameAs": [
           "https://twitter.com/tamir_dresher",
           "https://github.com/tamirdresher",
@@ -33,11 +33,11 @@
       },
       {
         "@type": "WebSite",
-        "@id": "https://tamirdresher.github.io/#website",
-        "url": "https://tamirdresher.github.io",
+        "@id": "{{ site.url }}{{ site.baseurl }}/#website",
+        "url": "{{ site.url }}{{ site.baseurl }}/",
         "name": "IBlogger — Tamir Dresher",
         "description": "Tamir Dresher's blog about .NET, reactive programming, distributed systems, AI, and software architecture.",
-        "author": { "@id": "https://tamirdresher.github.io/#author" }
+        "author": { "@id": "{{ site.url }}{{ site.baseurl }}/#author" }
       }
     ]
   }

--- a/tabs/products.md
+++ b/tabs/products.md
@@ -12,11 +12,11 @@ description: "Books, games, and digital products by Tamir Dresher — .NET, reac
   "@type": "CollectionPage",
   "name": "Products & Resources — Tamir Dresher",
   "description": "Books, games, and digital products by Tamir Dresher",
-  "url": "https://tamirdresher.github.io/tabs/products/",
+  "url": "{{ site.url }}{{ site.baseurl }}/tabs/products/",
   "author": {
     "@type": "Person",
     "name": "Tamir Dresher",
-    "url": "https://tamirdresher.github.io"
+    "url": "{{ site.url }}{{ site.baseurl }}/"
   },
   "hasPart": [
     {


### PR DESCRIPTION
## What

Fixes the Google Search Console '"'"'Page with redirect'"'"' coverage issue.

## Root Cause

`_config.yml` was still using `https://tamirdresher.github.io` as the site URL. This caused all canonical tags, sitemap entries, and structured data to reference the GitHub Pages hostname — which 301-redirects to `www.tamirdresher.com`. Google sees the canonical URL pointing to a redirecting URL and flags those pages as '"'"'Page with redirect'"'"', preventing indexing.

## Changes

| File | Change |
|------|--------|
| `_config.yml` | `url:` → `https://www.tamirdresher.com` |
| `_includes/head.html` | Replace hardcoded `tamirdresher.github.io` JSON-LD URLs with `{{ site.url }}` |
| `tabs/products.md` | Replace hardcoded `tamirdresher.github.io` JSON-LD URLs with Liquid-driven canonical URLs |

## Notes

- `robots.txt` already uses `{{ site.url }}` for the sitemap directive, so no change was needed.
- `sitemap.xml` already builds URLs from `site.url`, so updating `_config.yml` corrects sitemap output on the next deploy.

## After Merging

Re-submit the sitemap in Google Search Console: `https://www.tamirdresher.com/sitemap.xml`. The '"'"'Page with redirect'"'"' coverage errors should clear within a few days as Googlebot re-crawls.

Closes tamirdresher_microsoft/tamresearch1#3594
